### PR TITLE
secure_port for SPICE with TLS

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -85,6 +85,7 @@ module OVIRT
         :type => (xml/'display/type').first.text,
         :address => ((xml/'display/address').first.text rescue nil),
         :port => ((xml/'display/port').first.text rescue nil),
+        :secure_port => ((xml/'display/secure_port').first.text rescue nil),
         :monitors => (xml/'display/monitors').first.text
       }
       @cores = ((xml/'cpu/topology').first[:cores].to_i * (xml/'cpu/topology').first[:sockets].to_i rescue nil)


### PR DESCRIPTION
I was able to get spice working with TLS in Foreman but I need the secure_port to do so.
