### PR TITLE
bugfix: memory/cpu shouldn't be set when no memory/cpu options

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -49,10 +49,14 @@ module OVIRT
             cluster_{ name_(opts[:cluster_name])}
           end
           type_ opts[:hwp_id] || 'Server'
-          memory opts[:memory] ? opts[:memory].to_s : (512*1024*1024).to_s
-          cpu {
-            topology( :cores => (opts[:cores] || '1'), :sockets => '1' )
-          }
+          if opts[:memory]
+              memory opts[:memory]
+          end
+          if opts[:cores]
+             cpu {
+               topology( :cores => (opts[:cores] || '1'), :sockets => '1' )
+             }
+          end
           os{
             boot(:dev=> opts[:boot_dev1] || 'network')
             boot(:dev=> opts[:boot_dev2] || 'hd')


### PR DESCRIPTION
When memory /cpu isn't set in the options, we shouldn't set a default, as they are derived from the template.

I tested the fix, but couldn't run the unit-tests (they failed even without my fix).
If they are supposed to pass, can you try running them with this patch as well, or guide me how to do so?

Thank you,
Oved
