### PR TITLE
Change github URL back to abenari/rbovirt

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ require 'jeweler'
 Jeweler::Tasks.new do |gem|
   # gem is a Gem::Specification... see http://docs.rubygems.org/read/chapter/20 for more options
   gem.name = "rbovirt"
-  gem.homepage = "http://github.com/rbovirt/rbovirt"
+  gem.homepage = "http://github.com/abenari/rbovirt"
   gem.license = "MIT"
   gem.summary = %Q{A Ruby client for oVirt REST API}
   gem.description = %Q{A Ruby client for oVirt REST API}

--- a/rbovirt.gemspec
+++ b/rbovirt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
     "spec/spec_helper.rb",
     "spec/unit/vm_spec.rb"
   ]
-  s.homepage = "http://github.com/rbovirt/rbovirt"
+  s.homepage = "http://github.com/abenari/rbovirt"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.24"


### PR DESCRIPTION
Hey,

I guess now that we are left with abenari/rbovirt instead of rbovirt/rbovirt, then these files needs to be changed as well.
Ran "rake spec", and had 3 unrelated failures, so we can continue pushing this.
