### PR TITLE
Fix for DTACLOUD-437 Empty user-data genrated on rhevm3.1 instance

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -82,7 +82,7 @@ module OVIRT
           } if(opts[:user_data_method] && opts[:user_data_method] == :custom_property)
           payloads {
             payload(:type => 'floppy') {
-              _file(:name => "#{opts[:fileinject_path] || OVIRT::FILEINJECT_PATH}") { content(Base64::decode64(opts[:user_data])) }
+              file(:name => "#{opts[:fileinject_path] || OVIRT::FILEINJECT_PATH}") { content(Base64::decode64(opts[:user_data])) }
             }
           } if(opts[:user_data_method] && opts[:user_data_method] == :payload)
         }


### PR DESCRIPTION
User data file was not being passed correctly to rbovirt.

Payload was incorrectly structured using "_file" which should be "file".
The suspicion is a Nokogiri change likely surfaced this as it used to
work fine with "_file".

Signed-off-by: Joe VLcek jvlcek@redhat.com
