### PR TITLE
fixing clusters API when using user-level API

### DIFF
--- a/lib/client/cluster_api.rb
+++ b/lib/client/cluster_api.rb
@@ -17,7 +17,7 @@ module OVIRT
       http_get(path, headers).xpath('/clusters/cluster').collect do |cl|
         cluster = OVIRT::Cluster.new(self, cl)
         #the following line is needed as a work-around a bug in RHEV 3.0 rest-api
-        cluster if !filtered_api || (cluster.datacenter.id == current_datacenter.id)
+        cluster if filtered_api || (cluster.datacenter.id == current_datacenter.id)
       end.compact
     end
 


### PR DESCRIPTION
When using the user-level API (filtered view), we need to return all the
cluster the user sees, rather than only clusters in the current DC.
This patch fixes that issue (returning the cluster in case it is either
a filtered view, or in the current DC).
