### PR TITLE
Default boot device as hd with support for user requested network.

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -74,10 +74,17 @@ module OVIRT
                topology( :cores => (opts[:cores] || '1'), :sockets => '1' )
              }
           end
-          os{
-            boot(:dev=> opts[:boot_dev1] || 'network')
-            boot(:dev=> opts[:boot_dev2] || 'hd')
-          }
+          if(opts[:first_boot_dev] && opts[:first_boot_dev] == 'network')
+            os{
+              boot(:dev=> opts[:boot_dev1] || 'network')
+              boot(:dev=> opts[:boot_dev2] || 'hd')
+            }
+          else
+            os{
+              boot(:dev=> opts[:boot_dev2] || 'hd')
+              boot(:dev=> opts[:boot_dev1] || 'network')
+            }
+          end
           display_{
             type_(opts[:display])
           } if opts[:display]


### PR DESCRIPTION
This push changes the  default first boot device from "network" to "hard disk".
Support is also added to allow the user to explicitly switch the boot order to
network first and hard disk second.
