### PR TITLE
work around change in Red Hat bugzilla #1038053

### DIFF
--- a/lib/ovirt/datacenter.rb
+++ b/lib/ovirt/datacenter.rb
@@ -14,7 +14,7 @@ module OVIRT
     def parse_xml_attributes!(xml)
       @description = (xml/'description').first.text rescue nil
       @status = (xml/'status').first.text.strip
-      @storage_type = (xml/'storage_type').first.text
+      @storage_type = (xml/'storage_type').first.text rescue nil
       @storage_format = (xml/'storage_format').first.text rescue nil
       @supported_versions = (xml/'supported_versions').collect { |v|
         parse_version v


### PR DESCRIPTION
I'm not sure if this is the generally correct fix, but at least this gets my oVirt compute resource in foreman working again after updating oVirt to 3.4.0 beta 2
