### PR TITLE
Fix tests failure by requiring rspec/core instead of rspec.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require 'rspec/core'
 require 'rspec/mocks'
 require 'rbovirt'
 


### PR DESCRIPTION
Signed-off-by: Alissa Bonas abonas@redhat.com
