### PR TITLE
Support for using the persistent-auth

### DIFF
--- a/lib/rbovirt.rb
+++ b/lib/rbovirt.rb
@@ -45,7 +45,7 @@ module OVIRT
 
   class Client
 
-    attr_reader :credentials, :api_entrypoint, :datacenter_id, :cluster_id, :filtered_api, :ca_cert_file, :ca_cert_store, :ca_no_verify
+    attr_reader :credentials, :api_entrypoint, :datacenter_id, :cluster_id, :filtered_api, :ca_cert_file, :ca_cert_store, :ca_no_verify, :persistent_auth, :jsessionid
 
     # Construct a new ovirt client class.
     # mandatory parameters
@@ -67,14 +67,16 @@ module OVIRT
                    :cluster_id => backward_compatibility_cluster,
                    :filtered_api => backward_compatibility_filtered}
       end
-      @api_entrypoint = api_entrypoint
-      @credentials    = { :username => username, :password => password }
-      @datacenter_id  = options[:datacenter_id]
-      @cluster_id     = options[:cluster_id]
-      @filtered_api   = options[:filtered_api]
-      @ca_cert_file   = options[:ca_cert_file]
-      @ca_cert_store  = options[:ca_cert_store]
-      @ca_no_verify   = options[:ca_no_verify]
+      @api_entrypoint  = api_entrypoint
+      @credentials     = { :username => username, :password => password }
+      @datacenter_id   = options[:datacenter_id]
+      @cluster_id      = options[:cluster_id]
+      @filtered_api    = options[:filtered_api]
+      @ca_cert_file    = options[:ca_cert_file]
+      @ca_cert_store   = options[:ca_cert_store]
+      @ca_no_verify    = options[:ca_no_verify]
+      @persistent_auth = options[:persistent_auth]
+      @jsessionid      = options[:jsessionid]
     end
 
     def api_version
@@ -112,9 +114,7 @@ module OVIRT
 
     def http_get(suburl, headers={})
       begin
-        res = rest_client(suburl).get(http_headers(headers))
-        puts "#{res}\n" if ENV['RBOVIRT_LOG_RESPONSE']
-        Nokogiri::XML(res)
+        handle_success(rest_client(suburl).get(http_headers(headers)))
       rescue
         handle_fault $!
       end
@@ -122,9 +122,7 @@ module OVIRT
 
     def http_post(suburl, body, headers={})
       begin
-        res = rest_client(suburl).post(body, http_headers(headers))
-        puts "#{res}\n" if ENV['RBOVIRT_LOG_RESPONSE']
-        Nokogiri::XML(res)
+        handle_success(rest_client(suburl).post(body, http_headers(headers)))
       rescue
         handle_fault $!
       end
@@ -132,9 +130,7 @@ module OVIRT
 
     def http_put(suburl, body, headers={})
       begin
-        res = rest_client(suburl).put(body, http_headers(headers))
-        puts "#{res}\n" if ENV['RBOVIRT_LOG_RESPONSE']
-        Nokogiri::XML(res)
+        handle_success(rest_client(suburl).put(body, http_headers(headers)))
       rescue
         handle_fault $!
       end
@@ -144,9 +140,7 @@ module OVIRT
       begin
         headers = body ? http_headers(headers) :
           {:accept => 'application/xml'}.merge(auth_header).merge(filter_header)
-        res = rest_client(suburl).delete_with_payload(body, headers)
-        puts "#{res}\n" if ENV['RBOVIRT_LOG_RESPONSE']
-        Nokogiri::XML(res)
+        handle_success(rest_client(suburl).delete_with_payload(body, headers))
       rescue
         handle_fault $!
       end
@@ -155,7 +149,12 @@ module OVIRT
     def auth_header
       # This is the method for strict_encode64:
       encoded_credentials = ["#{@credentials[:username]}:#{@credentials[:password]}"].pack("m0").gsub(/\n/,'')
-      { :authorization => "Basic " + encoded_credentials }
+      headers = { :authorization => "Basic " + encoded_credentials }
+      if persistent_auth
+        headers[:prefer] = 'persistent-auth'
+        headers[:cookie] = "JSESSIONID=#{jsessionid}" if jsessionid
+      end
+      headers
     end
 
     def rest_client(suburl)
@@ -191,6 +190,12 @@ module OVIRT
         :content_type => 'application/xml',
         :accept => 'application/xml',
       }).merge(headers)
+    end
+
+    def handle_success(response)
+      puts "#{response}\n" if ENV['RBOVIRT_LOG_RESPONSE']
+      @jsessionid ||= response.cookies['JSESSIONID']
+      Nokogiri::XML(response)
     end
 
     def handle_fault(f)

--- a/spec/integration/api_spec.rb
+++ b/spec/integration/api_spec.rb
@@ -58,6 +58,28 @@ describe OVIRT, "Https authentication" do
   end
 end
 
+describe OVIRT, "Persistent authentication" do
+  context 'use persistent authentication' do
+
+    it "test_request_with_persistent_authentication" do
+      user, password, url, datacenter = endpoint
+      cert = ca_cert(url)
+      store = OpenSSL::X509::Store.new().add_cert(
+              OpenSSL::X509::Certificate.new(cert))
+
+      client = ::OVIRT::Client.new(user, password, url, {:ca_cert_store => store, :persistent_auth => true})
+      client.api_version.class.should eql(String)
+      client.persistent_auth.should eql(true)
+      client.jsessionid.should_not be_nil
+
+      # When performing a new request the jsessionid should remain the same
+      orig_jsession_id = client.jsessionid
+      client.datacenters.class.should eql(Array)
+      client.jsessionid.should eql(orig_jsession_id)
+    end
+  end
+end
+
 describe OVIRT, "Admin API" do
 
   before(:all) do

--- a/spec/integration/vm_crud_spec.rb
+++ b/spec/integration/vm_crud_spec.rb
@@ -51,6 +51,8 @@ shared_examples_for "Basic VM Life cycle" do
   end
 
   it "test_should_set_vm_ticket" do
+    while @client.vm(@vm.id).status.strip != 'down' do
+    end
     @client.vm_action(@vm.id, :start)
     while !@client.vm(@vm.id).running? do
     end
@@ -155,6 +157,16 @@ describe "VM API support functions" do
 
   before(:all) do
     setup_client
+    if @client.templates.empty?
+      name = 'vm-'+Time.now.to_i.to_s
+      @cluster = @client.clusters.select{|c| c.name == cluster_name}.first.id
+      vm = @client.create_vm(:name => name, :cluster => @cluster)
+      @client.add_volume(vm.id)
+      @client.add_interface(vm.id, :network_name => network_name)
+      while !@client.vm(vm.id).ready? do
+      end
+      @client.create_template(:vm => vm.id, :name => "template-#{name}", :description => "test_template", :comment => "test_template")
+    end
 
     @template_name = @config['template'] || @client.templates.first.name
     @template = @client.templates.find { |t| t.name == @template_name }.id


### PR DESCRIPTION
With persisted_auth set to true, we can by-pass the full ovirt authentication,
which can rapidly speed-up the response times
(at least when running against some external authentication).

In my setup, it is 4x faster with this feature turned on. For more details see
http://www.ovirt.org/Features/RESTSessionManagement.