### PR TITLE
add cloud_init support

### DIFF
--- a/lib/client/vm_api.rb
+++ b/lib/client/vm_api.rb
@@ -86,6 +86,12 @@ module OVIRT
       return (xml_response/'action/status').first.text.strip.upcase=="COMPLETE"
     end
 
+    def vm_start_with_cloudinit(id, opts={})
+      xml = OVIRT::VM.cloudinit(opts)
+      xml_response = http_post("/vms/%s/%s" % [id, 'start'], xml, {} )
+      return (xml_response/'action/status').first.text.strip.upcase=="COMPLETE"
+    end
+
     def destroy_vm(id)
       http_delete("/vms/%s" % id)
     end

--- a/spec/integration/vm_crud_spec.rb
+++ b/spec/integration/vm_crud_spec.rb
@@ -41,6 +41,15 @@ shared_examples_for "Basic VM Life cycle" do
     @client.vm_action(@vm.id, :shutdown)
   end
 
+  it "test_should_start_with_cloudinit" do
+    hostname = "host-"+Time.now.to_i.to_s
+    user_data={ :hostname => hostname }
+    @client.vm_start_with_cloudinit(@vm.id, user_data)
+    while !@client.vm(@vm.id).running? do
+    end
+    @client.vm_action(@vm.id, :shutdown)
+  end
+
   it "test_should_set_vm_ticket" do
     @client.vm_action(@vm.id, :start)
     while !@client.vm(@vm.id).running? do


### PR DESCRIPTION
those changes allow to optionally pass a user_data string to the vm_action so it it later passed as xml cloud init body for rhev .
the user_data string is parsed as yaml and accepts typical cloud-init content such as the following

``` yml
#cloud-config
hostname: HOSTNAME
nicname: NICNAME
netmask: NETMASK
gateway: GATEWAY
ip: IP
dns: 
 - DNS
domain: DOMAIN
password: PASSWORD
```
