### PR TITLE
Ignore .gem files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ pkg
 
 # For rubinius:
 #*.rbc
+
+# Ignore generated .gem files:
+*.gem


### PR DESCRIPTION
This patch modifies the .gitignore file so that generated .gem files will be
ignored and thus less likely to be included in commits by accident.

Signed-off-by: Juan Hernandez juan.hernandez@redhat.com
