### PR TITLE
Don't override default Rest Client delete method.

### DIFF
--- a/lib/rbovirt.rb
+++ b/lib/rbovirt.rb
@@ -137,7 +137,7 @@ module OVIRT
       begin
         headers = body ? http_headers(headers) :
           {:accept => 'application/xml'}.merge(auth_header).merge(filter_header)
-        res = rest_client(suburl).delete(body, headers)
+        res = rest_client(suburl).delete_with_payload(body, headers)
         puts "#{res}\n" if ENV['RBOVIRT_LOG_RESPONSE']
         Nokogiri::XML(res)
       rescue

--- a/lib/restclient_ext/resource.rb
+++ b/lib/restclient_ext/resource.rb
@@ -1,6 +1,6 @@
 module RestClient
   class Resource
-    def delete(payload, additional_headers={}, &block)
+    def delete_with_payload(payload, additional_headers={}, &block)
       headers = (options[:headers] || {}).merge(additional_headers)
       Request.execute(options.merge(
         :method => :delete,


### PR DESCRIPTION
This override breaks any other projects use of RestClient that relies
on this gem.