### PR TITLE
Fix for cloudinit so nokogiri correctly processes the files section

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -224,7 +224,7 @@ module OVIRT
               regenerate_ssh_keys 'true'
               files {
                 unless extracmd.nil?
-                  file {
+                  file_ {
                     name_   'ignored'
                     content extracmd
                     type    'PLAINTEXT'


### PR DESCRIPTION
experienced weird issues with the file section which is probably a nokogiri keyword, seems to be solved by this underscore add 