### PR TITLE
Fix broken OVIRT::Template#volumes

### DIFF
--- a/lib/ovirt/template.rb
+++ b/lib/ovirt/template.rb
@@ -25,7 +25,7 @@ module OVIRT
     end
 
     def volumes
-      @volumes ||= @client.send(:volumes, "/templates/%s/disks" % id)
+      @volumes ||= @client.template_volumes(id)
     end
 
     private


### PR DESCRIPTION
This patch fixes the issues when information on template volumes is requested by using `template_volumes` method.

@jhernand, @abenari Do you forsee any incompatibility issues? 