### PR TITLE
Option to specify storage domain for a VM created from a template

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -99,7 +99,16 @@ module OVIRT
               priority_(opts[:ha_priority]) unless opts[:ha_priority].nil?
             }
           end
-          disks_ { clone_(opts[:clone]) } if opts[:clone]
+          disks_ {
+            clone_(opts[:clone]) if opts[:clone]
+            if opts[:disks]
+              for d in opts[:disks]
+                disk(:id => d[:id]) {
+                  storage_domains { storage_domain(:id => d[:storagedomain]) }
+                }
+              end
+            end
+          }
           display_{
             type_(opts[:display][:type])
           } if opts[:display]

--- a/spec/integration/vm_crud_spec.rb
+++ b/spec/integration/vm_crud_spec.rb
@@ -117,6 +117,7 @@ shared_examples_for "VM Life cycle without template" do
   end
 end
 
+
 describe "Admin API VM Life cycle" do
 
   before(:all) do
@@ -149,3 +150,106 @@ describe "User API VM Life cycle" do
     it_behaves_like "Basic VM Life cycle"
   end
 end
+
+describe "VM API support functions" do
+
+  before(:all) do
+    setup_client
+
+    # Skip first, blank template. It won't work here.
+    @template = @client.templates[1].id
+    @template_name = @client.templates[1].name
+    @storagedomain = @client.storagedomains.first.id
+    @storagedomain_name = @client.storagedomains.first.name
+  end
+
+  context 'options processing' do
+    it "should process template option into disk decriptions" do
+      t_id = @template
+      opts = {:template => t_id}
+      t_name = opts[:template_name]
+      @client.process_vm_opts(opts)
+      opts[:template].should eql(t_id)
+      opts[:template_name].should eql(t_name)
+    end
+
+    it "should process template_name option into disk decriptions" do
+      t_name = @template_name
+      opts = {:template_name => t_name}
+      t_id = opts[:template]
+      @client.process_vm_opts(opts)
+      opts[:template].should eql(t_id)
+      opts[:template_name].should eql(t_name)
+    end
+
+    it "should process template and storagedomain options into disk decriptions" do
+      t_id = @template
+      s_id = @storagedomain
+      opts = {:template => t_id,
+              :storagedomain => s_id}
+      t_name = opts[:template_name]
+      s_name = opts[:storagedomain_name]
+      @client.process_vm_opts(opts)
+      opts[:disks].length.should eql(1)
+      opts[:disks].first[:id].should_not be_nil
+      opts[:disks].first[:storage_domain].should eql(s_id)
+      opts[:template].should eql(t_id)
+      opts[:template_name].should eql(t_name)
+      opts[:storagedomain].should eql(s_id)
+      opts[:storagedomain_name].should eql(s_name)
+    end
+
+    it "should process template_name and storagedomain options into disk decriptions" do
+      t_name = @template_name
+      s_id = @storagedomain
+      opts = {:template_name => t_name,
+              :storagedomain => s_id}
+      t_id = opts[:template]
+      s_name = opts[:storagedomain_name]
+      @client.process_vm_opts(opts)
+      opts[:disks].length.should eql(1)
+      opts[:disks].first[:id].should_not be_nil
+      opts[:disks].first[:storage_domain].should eql(s_id)
+      opts[:template].should eql(t_id)
+      opts[:template_name].should eql(t_name)
+      opts[:storagedomain].should eql(s_id)
+      opts[:storagedomain_name].should eql(s_name)
+    end
+
+    it "should process template and storagedomain_name options into disk decriptions" do
+      t_id = @template
+      s_name = @storagedomain_name
+      opts = {:template => t_id,
+              :storagedomain_name => s_name}
+      t_name = opts[:template_name]
+      s_id = opts[:storagedomain_id]
+      @client.process_vm_opts(opts)
+      opts[:disks].length.should eql(1)
+      opts[:disks].first[:id].should_not be_nil
+      opts[:disks].first[:storage_domain].should eql(@storagedomain)
+      opts[:template].should eql(t_id)
+      opts[:template_name].should eql(t_name)
+      opts[:storagedomain].should eql(s_id)
+      opts[:storagedomain_name].should eql(s_name)
+    end
+
+    it "should process template_name and storagedomain_name options into disk decriptions" do
+      t_name = @template_name
+      s_name = @storagedomain_name
+      opts = {:template_name => t_name,
+              :storagedomain_name => s_name}
+      t_id = opts[:template]
+      s_id = opts[:storagedomain]
+      @client.process_vm_opts(opts)
+      opts[:disks].length.should eql(1)
+      opts[:disks].first[:id].should_not be_nil
+      opts[:disks].first[:storage_domain].should eql(@storagedomain)
+      opts[:template].should eql(t_id)
+      opts[:template_name].should eql(t_name)
+      opts[:storagedomain].should eql(s_id)
+      opts[:storagedomain_name].should eql(s_name)
+    end
+
+  end
+end
+

--- a/spec/unit/vm_spec.rb
+++ b/spec/unit/vm_spec.rb
@@ -257,6 +257,25 @@ END_HEREDOC
       Nokogiri::XML(xml).xpath("//description")[0].content.should eql("a description")
     end
 
+    it "create vm xml with disks" do
+      disk = "00000000-0000-0000-0000-000000000000"
+      storagedomain = "00000000-0000-0000-0000-000000000001"
+      disks = [{:id => disk, :storagedomain => storagedomain}]
+      opts = {
+          :cluster_name => 'cluster',
+          :disks => disks,
+      }
+      xml = OVIRT::VM.to_xml(opts)
+      puts xml
+      xml.nil?.should eql(false)
+      Nokogiri::XML(xml).xpath("//disks").length.should eql(1)
+      Nokogiri::XML(xml).xpath("//disks")[0].element_children.length.should eql(1)
+      Nokogiri::XML(xml).xpath("//disks/disk[contains(@id,'#{disk}')]").length.should eql(1)
+      Nokogiri::XML(xml).xpath("//disks/disk/storage_domains").length.should eql(1)
+      Nokogiri::XML(xml).xpath("//disks/disk/storage_domains")[0].element_children.length.should eql(1)
+      Nokogiri::XML(xml).xpath("//disks/disk/storage_domains/storage_domain[contains(@id,'#{storagedomain}')]").length.should eql(1)
+    end
+
     it "should be running" do
       vm = OVIRT::VM.new(nil, Nokogiri::XML(@xml).xpath('/').first)
       vm.running?.should eql(true)


### PR DESCRIPTION
Add option to specify storage domain to use when creating a VM from a template.

Additional code to generate XML for disk specifications, and to generate disk specifications from template and storage domain configuration options.

Code and tests.

Tests require a template other than Blank to be present in oVirt environment used for test.