### PR TITLE
Implement cloud-init for multiple nics

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -137,6 +137,7 @@ module OVIRT
       gateway             = opts[:gateway]
       domain              = opts[:domain]
       nicname             = opts[:nicname]
+      nicsdef             = opts[:nicsdef]
       user                = opts[:user] || 'root'
       password            = opts[:password]
       ssh_authorized_keys = opts[:ssh_authorized_keys]
@@ -195,18 +196,35 @@ module OVIRT
                     }
                   }
                 end
-                network_configuration { 
-                  unless nicname.nil?
+                network_configuration {
+                  if !nicname.nil?
                     nics {
                       nic {
-	                name_ nicname
+                        name_ nicname
                         unless ip.nil? || netmask.nil? || gateway.nil?
                           network { ip(:'address'=> ip , :'netmask'=> netmask, :'gateway'=> gateway ) }
                           boot_protocol 'STATIC'
                           on_boot 'true'
                         end 
                       }
-                    } 
+                    }
+                  elsif !nicsdef.nil?
+                    nics {
+                      nicsdef.each do |n|
+                        nic {
+                          name_(n[:nicname])
+                          boot_protocol_(n[:boot_protocol] || 'NONE') # Defaults to NONE boot proto
+                          on_boot_(n[:on_boot] || 'true') # Defaults to 'true'
+                          unless n[:ip].nil? || n[:netmask].nil?
+                            network_ {
+                              n[:gateway].nil? ?
+                              ip_(:address => n[:ip], :netmask => n[:netmask]) :
+                              ip_(:address => n[:ip], :netmask => n[:netmask], :gateway => n[:gateway])
+                            }
+                          end
+                        }
+                      end
+                    }
                   end
                   dns { 
                     unless dns.nil? 

--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -208,7 +208,7 @@ module OVIRT
                         end 
                       }
                     }
-                  elsif !nicsdef.nil?
+                  elsif nicsdef.is_a?(Array) && !nicsdef.empty? && nicsdef.all? { |n| n.is_a?(Hash) }
                     nics {
                       nicsdef.each do |n|
                         nic {


### PR DESCRIPTION
Implement support for configuration of multiple NICs within cloud-init and keep it backward compatible with previous approach.

Following are some details. NICs definition is a list of hashes and is passed to `OVIRT::VM#cloudinit` via the `opts[:nicsdef]` option.

The format should be the following:
```
opts[:nicsdef] = [
  {
    :nicname => 'eth0',
    :boot_protocol => 'STATIC',
    :ip => '192.168.1.25',
    :netmask => '255.255.255.0',
    :gateway => '192.168.1.254'
  },
  {
    :nicname => 'eth1',
    :boot_protocol => 'STATIC',
    :ip => '192.168.2.25',
    :netmask => '255.255.255.0',
  },
  {
    :nicname => 'eth2'
  }
]

opts[:nicsdef] = [
  {
    :nicname => 'eth0',
    :boot_protocol => 'DHCP'
  }
]
```
Each NIC is configured to:
 * default to `'NONE'` boot protocol if `:boot_protocol` is not specified,
 * default to `'true'` if `:on_boot` is unspecified.

The `:gateway` is optional for a NIC definition thus letting the user to specify which interface should be used for a default gateway.

Please note that `opts[:nicsdef]` is evaluated if `opts[:nicname]` is also defined, i.e. definition of `opts[:nicname]` has a higher precedence than `opts[:nicsdef]`.

@abenari, @jhernand: Would it be possible to merge this into upstream?