### PR TITLE
Enhance handling of template disk(s) if storage domain option is specified explicitly

### DIFF
--- a/lib/client/vm_api.rb
+++ b/lib/client/vm_api.rb
@@ -19,7 +19,7 @@ module OVIRT
         template_id = opts[:template] || templates.select{|t| t.name == opts[:template_name]}.first.id
         disk_id = template_volumes(template_id).first.id
         storagedomain_id = opts[:storagedomain] || storagedomains.select{|s| s.name == opts[:storagedomain_name]}.first.id
-        opts[:disks] = [{:id => disk_id, :storage_domain => storagedomain_id}]
+        opts[:disks] = [{:id => disk_id, :storagedomain => storagedomain_id}]
       end
     end
 

--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -102,7 +102,7 @@ module OVIRT
           disks_ {
             clone_(opts[:clone]) if opts[:clone]
             if opts[:disks]
-              for d in opts[:disks]
+              opts[:disks].each do |d|
                 disk(:id => d[:id]) {
                   storage_domains { storage_domain(:id => d[:storagedomain]) }
                 }

--- a/spec/integration/vm_crud_spec.rb
+++ b/spec/integration/vm_crud_spec.rb
@@ -156,9 +156,9 @@ describe "VM API support functions" do
   before(:all) do
     setup_client
 
-    # Skip first, blank template. It won't work here.
-    @template = @client.templates[1].id
-    @template_name = @client.templates[1].name
+    @template_name = @config['template'] || @client.templates.first.name
+    @template = @client.templates.find { |t| t.name == @template_name }.id
+    @template_disks = @client.template_volumes(@template)
     @storagedomain = @client.storagedomains.first.id
     @storagedomain_name = @client.storagedomains.first.name
   end
@@ -190,9 +190,9 @@ describe "VM API support functions" do
       t_name = opts[:template_name]
       s_name = opts[:storagedomain_name]
       @client.process_vm_opts(opts)
-      opts[:disks].length.should eql(1)
+      opts[:disks].length.should eql(@template_disks.length)
       opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storage_domain].should eql(s_id)
+      opts[:disks].first[:storagedomain].should eql(s_id)
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)
@@ -207,9 +207,9 @@ describe "VM API support functions" do
       t_id = opts[:template]
       s_name = opts[:storagedomain_name]
       @client.process_vm_opts(opts)
-      opts[:disks].length.should eql(1)
+      opts[:disks].length.should eql(@template_disks.length)
       opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storage_domain].should eql(s_id)
+      opts[:disks].first[:storagedomain].should eql(s_id)
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)
@@ -224,9 +224,9 @@ describe "VM API support functions" do
       t_name = opts[:template_name]
       s_id = opts[:storagedomain_id]
       @client.process_vm_opts(opts)
-      opts[:disks].length.should eql(1)
+      opts[:disks].length.should eql(@template_disks.length)
       opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storage_domain].should eql(@storagedomain)
+      opts[:disks].first[:storagedomain].should eql(@storagedomain)
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)
@@ -241,9 +241,9 @@ describe "VM API support functions" do
       t_id = opts[:template]
       s_id = opts[:storagedomain]
       @client.process_vm_opts(opts)
-      opts[:disks].length.should eql(1)
+      opts[:disks].length.should eql(@template_disks.length)
       opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storage_domain].should eql(@storagedomain)
+      opts[:disks].first[:storagedomain].should eql(@storagedomain)
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)

--- a/spec/integration/vm_crud_spec.rb
+++ b/spec/integration/vm_crud_spec.rb
@@ -191,8 +191,10 @@ describe "VM API support functions" do
       s_name = opts[:storagedomain_name]
       @client.process_vm_opts(opts)
       opts[:disks].length.should eql(@template_disks.length)
-      opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storagedomain].should eql(s_id)
+      unless @template_disks.empty?
+        opts[:disks].first[:id].should_not be_nil
+        opts[:disks].first[:storagedomain].should eql(s_id)
+      end
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)
@@ -208,8 +210,10 @@ describe "VM API support functions" do
       s_name = opts[:storagedomain_name]
       @client.process_vm_opts(opts)
       opts[:disks].length.should eql(@template_disks.length)
-      opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storagedomain].should eql(s_id)
+      unless @template_disks.empty?
+        opts[:disks].first[:id].should_not be_nil
+        opts[:disks].first[:storagedomain].should eql(s_id)
+      end
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)
@@ -225,8 +229,10 @@ describe "VM API support functions" do
       s_id = opts[:storagedomain_id]
       @client.process_vm_opts(opts)
       opts[:disks].length.should eql(@template_disks.length)
-      opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storagedomain].should eql(@storagedomain)
+      unless @template_disks.empty?
+        opts[:disks].first[:id].should_not be_nil
+        opts[:disks].first[:storagedomain].should eql(@storagedomain)
+      end
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)
@@ -242,8 +248,10 @@ describe "VM API support functions" do
       s_id = opts[:storagedomain]
       @client.process_vm_opts(opts)
       opts[:disks].length.should eql(@template_disks.length)
-      opts[:disks].first[:id].should_not be_nil
-      opts[:disks].first[:storagedomain].should eql(@storagedomain)
+      unless @template_disks.empty?
+        opts[:disks].first[:id].should_not be_nil
+        opts[:disks].first[:storagedomain].should eql(@storagedomain)
+      end
       opts[:template].should eql(t_id)
       opts[:template_name].should eql(t_name)
       opts[:storagedomain].should eql(s_id)


### PR DESCRIPTION
This is based on #89 but it implements:
 * Cloning of disk(s) into a specified storage domain by setting the `clone` option in case any of the template's disk(s) originates on a different storage domain than specified. The VM creation may fail without setting the `clone` flag, because (at least) RHEVm tries to create a dependent/cloned VMs from a template.
 * Creation of VMs based on templates with multiple disks, i.e. all target disks are provisioned onto a storage domain that is specified in VM creation `opts` hash.
 * Proper handling of templates without disks.

Tests have also been reworked a bit to reflect the changes. One may even specify a template to use in tests by adding `template` configuration parameter into `spec/endpoint.yml`.

@pparkin, thanks for your work. Let me know if this PR is fine for you.
@jhernand, would be great if you cloud merge this into a master branch.