### PR TITLE
Add api version checks in `OVIRT::VM::cloudinit` 

### DIFF
--- a/lib/client/vm_api.rb
+++ b/lib/client/vm_api.rb
@@ -17,15 +17,9 @@ module OVIRT
     def process_vm_opts(opts)
       if (opts[:template] or opts[:template_name]) and (opts[:storagedomain] or opts[:storagedomain_name])
         template_id = opts[:template] || templates.select{|t| t.name == opts[:template_name]}.first.id
-        template_disks = template_volumes(template_id)
+        disk_id = template_volumes(template_id).first.id
         storagedomain_id = opts[:storagedomain] || storagedomains.select{|s| s.name == opts[:storagedomain_name]}.first.id
-
-        # Make sure the 'clone' option is set if any of the disks defined by
-        # the template is stored on a different storage domain than requested
-        opts[:clone] = true unless opts[:clone] == true || template_disks.empty? || template_disks.all? { |d| d.storage_domain == storagedomain_id }
-
-        # Create disks map
-        opts[:disks] = template_disks.collect { |d| {:id => d.id, :storagedomain => storagedomain_id} }
+        opts[:disks] = [{:id => disk_id, :storage_domain => storagedomain_id}]
       end
     end
 
@@ -140,10 +134,13 @@ module OVIRT
     end
 
     def vm_start_with_cloudinit(id, opts={})
-      # Get the version of the cluster on which the VM is provisioned. This is
-      # required for VM::cloudinit.
-      cluster_major_ver, cluster_minor_ver = cluster_version(vm(id).cluster.id)
-      xml = OVIRT::VM.cloudinit(opts.merge(:cluster_major_ver => cluster_major_ver, :cluster_minor_ver => cluster_minor_ver))
+      # Get the api and cluster version on which the VM is provisioned.
+      # This is required for VM::cloudinit.
+      opts.merge!(
+        :cluster_version => cluster_version(vm(id).cluster.id),
+        :api_version => api_version.split('.').map(&:to_i)
+      )
+      xml = OVIRT::VM.cloudinit(opts)
       xml_response = http_post("/vms/%s/%s" % [id, 'start'], xml, {} )
       return (xml_response/'action/status').first.text.strip.upcase=="COMPLETE"
     end

--- a/lib/client/vm_api.rb
+++ b/lib/client/vm_api.rb
@@ -17,9 +17,15 @@ module OVIRT
     def process_vm_opts(opts)
       if (opts[:template] or opts[:template_name]) and (opts[:storagedomain] or opts[:storagedomain_name])
         template_id = opts[:template] || templates.select{|t| t.name == opts[:template_name]}.first.id
-        disk_id = template_volumes(template_id).first.id
+        template_disks = template_volumes(template_id)
         storagedomain_id = opts[:storagedomain] || storagedomains.select{|s| s.name == opts[:storagedomain_name]}.first.id
-        opts[:disks] = [{:id => disk_id, :storage_domain => storagedomain_id}]
+
+        # Make sure the 'clone' option is set if any of the disks defined by
+        # the template is stored on a different storage domain than requested
+        opts[:clone] = true unless opts[:clone] == true || template_disks.empty? || template_disks.all? { |d| d.storage_domain == storagedomain_id }
+
+        # Create disks map
+        opts[:disks] = template_disks.collect { |d| {:id => d.id, :storagedomain => storagedomain_id} }
       end
     end
 

--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -102,7 +102,7 @@ module OVIRT
           disks_ {
             clone_(opts[:clone]) if opts[:clone]
             if opts[:disks]
-              for d in opts[:disks]
+              opts[:disks].each do |d|
                 disk(:id => d[:id]) {
                   storage_domains { storage_domain(:id => d[:storagedomain]) }
                 }

--- a/lib/rbovirt.rb
+++ b/lib/rbovirt.rb
@@ -80,7 +80,11 @@ module OVIRT
     def api_version
       return @api_version unless @api_version.nil?
       xml = http_get("/")/'/api/product_info/version'
-      @api_version = (xml/'version').first[:major] +"."+ (xml/'version').first[:minor]
+      major = (xml/'version').first[:major]
+      minor = (xml/'version').first[:minor]
+      build = (xml/'version').first[:build]
+      revision = (xml/'version').first[:revision]
+      @api_version = "#{major}.#{minor}.#{build}.#{revision}"
     end
 
     def api_version?(major, minor=nil)


### PR DESCRIPTION
The PR #93 has solved the problem only partially. This PR adds API version checks to make sure that a conditional inclusion of `<use_cloud_init>true</use_cloud_init>` is also supported by the engine itself.

__NOTE__: RHEV-m/OVirt versions prior to 3.6.0 contain a bug (https://bugzilla.redhat.com/show_bug.cgi?id=1206068) which causes that `build` and `revision` parameters of API version are set to `0`. This may have an impact on conditional inclusion of `<use_cloud_init>` and thus leaving the guest unconfigured. One can either upgrade to RHEV-m/OVirt 3.6+ or work this around manually by forcing the ovirt engine to report an appropriate version:
```
# rhevm-config -s VdcVersion=<major>.<minor>.<build>.<revision>
# service ovirt-engine restart
```
Please replace the placeholders with appropriate values.

@jhernand Would you be OK to merge this upstream please? Thanks.
