### PR TITLE
account for no template version_name

### DIFF
--- a/lib/ovirt/template_version.rb
+++ b/lib/ovirt/template_version.rb
@@ -8,7 +8,7 @@ module OVIRT
     def parse_xml_attributes(xml)
       @base_template = (xml/"base_template").first[:id]
       @version_number = (xml/"version_number").first.text
-      @version_name = (xml/"version_name").first.text
+      @version_name = ((xml/"version_name").first.text rescue nil)
     end
   end
 end


### PR DESCRIPTION
It seems possible for a template to not have a version_name. I uploaded a CFME template and have:
```
<version>
  <base_template href="/api/templates/757219ca-efcb-4751-b980-7be32d8b43e0" id="757219ca-efcb-4751-b980-7be32d8b43e0"/>
  <version_number>1</version_number>
</version>
```

But on the Blank Template that comes with RHEV I do see:

```
<version>
  <base_template href="/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
  <version_number>1</version_number>
  <version_name>base version</version_name>
</version>
```