### PR TITLE
Explicitly use version 3 of the API

### DIFF
--- a/lib/rbovirt.rb
+++ b/lib/rbovirt.rb
@@ -147,7 +147,7 @@ module OVIRT
     def http_delete(suburl, body=nil, headers={})
       begin
         headers = body ? http_headers(headers) :
-          {:accept => 'application/xml'}.merge(auth_header).merge(filter_header)
+          {:accept => 'application/xml', :version => '3'}.merge(auth_header).merge(filter_header)
         handle_success(rest_client(suburl).delete_with_payload(body, headers))
       rescue
         handle_fault $!
@@ -197,6 +197,7 @@ module OVIRT
       filter_header.merge(auth_header).merge({
         :content_type => 'application/xml',
         :accept => 'application/xml',
+        :version => '3',
       }).merge(headers)
     end
 


### PR DESCRIPTION
Version 4 of the oVirt engine will support two versions of the API:
version 3, which will be backwards compatible with older versions of the
engine and version 4, which won't be compatible. The default used by the
server will be version 4, but clients can explicitly request a version
of the API using the "Version" header or the "/v3" URL prefix. The
header is the preferred mechanism because it is just ignored by older
versions of the server. This patch modifies the the gem so that it
always send the header explicitly, so that it will work with version 4
of the engine.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>