### PR TITLE
Blank template does not contain a <cluster> element

### DIFF
--- a/lib/ovirt/template.rb
+++ b/lib/ovirt/template.rb
@@ -37,7 +37,9 @@ module OVIRT
       @status = ((xml/'status').first.text rescue 'unknown')
       @memory = (xml/'memory').first.text
       @profile = (xml/'type').first.text
-      @cluster = Link::new(@client, (xml/'cluster').first[:id], (xml/'cluster').first[:href])
+      if (xml/'cluster').first
+        @cluster = Link::new(@client, (xml/'cluster').first[:id], (xml/'cluster').first[:href])
+      end
       @display = {
         :type => ((xml/'display/type').first.text rescue ''),
         :monitors => ((xml/'display/monitors').first.text rescue 0)


### PR DESCRIPTION
When :filtered_api == true the template search result includes the Blank template
XML with no <cluster> element.
