### PR TITLE
Qci rhev4b integration

### DIFF
--- a/lib/ovirt/volume.rb
+++ b/lib/ovirt/volume.rb
@@ -56,8 +56,8 @@ module OVIRT
      @storage_domain = ((xml/'storage_domains/storage_domain').first[:id] rescue nil)
      @size = (xml/'size').first.text
      @disk_type = ((xml/'type').first.text rescue nil)
-     @bootable = (xml/'bootable').first.text
-     @interface = (xml/'interface').first.text
+     @bootable = ((xml/'bootable').first.text rescue nil)
+     @interface = ((xml/'interface').first.text rescue nil)
      @format = ((xml/'format').first.text rescue nil)
      @sparse = ((xml/'sparse').first.text rescue nil)
      @status = ((xml/'status/state').first.text rescue nil)

--- a/spec/unit/volume_spec.rb
+++ b/spec/unit/volume_spec.rb
@@ -1,0 +1,28 @@
+require "#{File.dirname(__FILE__)}/../spec_helper"
+
+describe OVIRT::Volume do
+
+xml = <<END_HEREDOC
+<disk href="/api/vms/76d29095-bc27-4cd0-8178-07e942aea549/nics/12345678-1234-1234-1234-123456789012" id="12345678-1234-1234-1234-123456789012">
+<name>disk1</name>
+<size>53687091200</size>
+<provisioned_size>53687091200</provisioned_size>
+<actual_size>143360</actual_size>
+<shareable>false</shareable>
+<propagate_errors>false</propagate_errors>
+<active>true</active>
+</disk>
+END_HEREDOC
+    vol =  OVIRT::Volume::new(nil, Nokogiri::XML(xml).xpath('/').first)
+
+    it "volume's bootable should be nil, since it was not specified" do
+      vol.bootable.should eql(nil)
+    end
+
+    it "volume's interface should be nil, since it was not specified" do
+      vol.interface.should eql(nil)
+    end
+
+end
+
+


### PR DESCRIPTION
These changes are required for QCI Integration of the RHEV4 Beta to work with Satellite v6.2.  Using v3 API, Satellite's create "Compute Resource" was failing, due to missing 'bootable' and 'interface' fields in the returned volume data.