### PR TITLE
Name servers and search domains should be passed as space separated strings

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -260,15 +260,15 @@ module OVIRT
                     }
                   end
                   dns { 
-                    unless dns.nil? 
-                      servers {
-                        dns.each do |dnsentry|
-                          host {  address dnsentry }
-                        end
-                      }
+                    if dns.is_a?(String)
+                      servers { host { address dns }}
+                    elsif dns.is_a?(Array) && dns.all? {|n| n.is_a?(String) }
+                      servers { host { address dns.join(' ') }}
                     end
-                    unless domain.nil? 
+                    if domain.is_a?(String)
                       search_domains { host {  address domain }}
+                    elsif domain.is_a?(Array) && domain.all? {|n| n.is_a?(String) }
+                      search_domains { host { address domain.join(' ')}}
                     end
                   }
                 }


### PR DESCRIPTION
Name servers and search domains should be space separated strings, otherwise `ovirt-engine` produces contactenated strings that a passed to `cloud-init`, hence `/etc/resolv.conf` is generated with invalid values as in example bellow:
```
# cat /etc/resolv.conf
namaserver 1.1.1.11.1.1.2
search foo.barfoo.baz
```

This patch fixes the issue.