### PR TITLE
Add mtu vlan_id and usages to networks

### DIFF
--- a/lib/ovirt/network.rb
+++ b/lib/ovirt/network.rb
@@ -1,6 +1,6 @@
 module OVIRT
  class Network < BaseObject
-    attr_reader :description, :datacenter, :cluster, :stp, :status
+    attr_reader :description, :datacenter, :cluster, :vlan_id, :mtu, :stp, :usages, :status
 
     def initialize(client, xml)
       super(client, xml[:id], xml[:href], (xml/'name').first.text)
@@ -13,6 +13,9 @@ module OVIRT
     def parse_xml_attributes!(xml)
       @description = ((xml/'description').first.text rescue nil)
       @stp = ((xml/'stp').first.text rescue false)
+      @mtu = ((xml/'mtu').first.text rescue nil)
+      @vlan_id = ((xml/'vlan').first[:id] rescue nil)
+      @usages = ((xml/'usages/usage').collect{ |usage| usage.text } rescue [])
       @datacenter = Link::new(@client, (xml/'data_center').first[:id], (xml/'data_center').first[:href]) unless (xml/'data_center').empty?
       @cluster = Link::new(@client, (xml/'cluster').first[:id], (xml/'cluster').first[:href]) unless (xml/'cluster').empty?
       @status = ((xml/'status/state').first.text rescue nil)


### PR DESCRIPTION
Adding new attributes mapping for networks. The vlan id and usages attributes are needed if we want to work on http://theforeman.org/issues/10539 "Feature #10539: Automatically assign oVirt name and network - Foreman".

Tested on oVirt 4.0.5 with v3 API