### PR TITLE
Support for multi-line runcmd params

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -174,8 +174,9 @@ module OVIRT
       unless runcmd.nil?
         runcmd.each do |cmd|
           cmdlist = \
-	  "#{cmdlist}\n" \
-          "- #{cmd}\n"
+          "#{cmdlist}\n" \
+          "- |\n"\
+          "  #{cmd.lines.join("  ")}\n"
         end
         if extracmd.nil?
           extracmd = cmdlist


### PR DESCRIPTION
In Foreman, we use cloud-init templates like this:

```
runcmd:
  - |
    echo 1
    echo 2
    echo 3
  - |
    echo a
    echo b
    echo c
```

Currently, the rbovirt is preparing the cloud-init template, it
counts on the fact the runcmd are only single lines, which limits
it's use significantly.