### PR TITLE
Support passing custom script to start_with_cloudinit

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -162,26 +162,22 @@ module OVIRT
       runcmd              = opts[:runcmd]
       cluster_major, cluster_minor = opts[:cluster_version]
       api_major,api_minor, api_build, api_revision = opts[:api_version]
-      extracmd            = nil 
+      extracmd            = opts[:custom_script]
       unless opts[:phone_home].nil?
         phone_home = \
         "phone_home:\n" \
         "  url: #{opts[:phone_home]['url']}\n" \
         "  post: #{opts[:phone_home]['post']}\n"
-        extracmd   = phone_home
+        extracmd = "#{extracmd}#{phone_home}"
       end
-      cmdlist             = 'runcmd:'
+      cmdlist = 'runcmd:'
       unless runcmd.nil?
         runcmd.each do |cmd|
           cmdlist = \
 	  "#{cmdlist}\n" \
           "- #{cmd}\n"
         end
-        if extracmd.nil?
-          extracmd = cmdlist
-        else
-          extracmd = extracmd +cmdlist
-        end
+        extracmd   = "#{extracmd}#{cmdlist}"
       end
       builder   = Nokogiri::XML::Builder.new do
         action {
@@ -204,12 +200,7 @@ module OVIRT
           end
           vm {
             initialization {
-              unless runcmd.nil?
-                custom_script cmdlist
-              end
-              unless phone_home.nil?
-                custom_script phone_home
-              end
+              custom_script extracmd if extracmd
               cloud_init {
                 unless hostname.nil?
                   host { address hostname  }


### PR DESCRIPTION
Currently, the cloud-init integration supports only a sub-set of
cloud-init commands. With `custom_script` support, one can pass
arbitrary cloud-init yaml to the managed host and make sure
the provisioned host will get it unchanged (which is not the case
when passing the user data currently, as the rbovirt parses into
ovirt-specific keys)

Example:

```
cloudinit = <<EOF
yum_repos:
    zoo:
        baseurl: https://example.com/yumrepo
        name: example-repo
        enabled: true
EOF

service.vm_start_with_cloudinit(:id =>id,
  :user_data => { :custom_script => cloudinit }
)
```

There is no way to achieve this without this patch.