### PR TITLE
Replace unknown constant with string

### DIFF
--- a/lib/client/host_api.rb
+++ b/lib/client/host_api.rb
@@ -17,14 +17,14 @@ module OVIRT
         http_post("/hosts/%s/approve" % host_id, "<action></action>")
     end
 
-    def reinstall_host(host_id, override_iptables=False, opts={})
+    def reinstall_host(host_id, override_iptables=false, opts={})
         http_post("/hosts/%s/install" % host_id,
                   "<action>
                     <ssh>
                      <authentication_method>PublicKey</authentication_method>
                     </ssh>
                     <host>
-                     <override_iptables>" + override_iptables + "</override_iptables>
+                     <override_iptables>" + override_iptables.to_s + "</override_iptables>
                     </host>
                    </action>"
                  )


### PR DESCRIPTION
The 'False' is an unknown constant:
 NameError: uninitialized constant OVIRT::Client::False

Also the method expects the provided value to be a string, so it can be
concatenated to the request to be sent.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1506547