### PR TITLE
update CHANGES.rdoc to v0.1.7

### DIFF
--- a/CHANGES.rdoc
+++ b/CHANGES.rdoc
@@ -6,6 +6,19 @@ _rbovirt_ project.
 Note that this list of changes was added with the 0.0.30 release,
 previous releases aren't described here.
 
+== 0.1.7
+
+New features:
+
+* Fix sockets when template is selected
+
+== 0.1.6
+
+New features:
+
+* Add socket to VM
+* Replace unknown constant with boolean
+
 == 0.1.5
 
 New features:


### PR DESCRIPTION
Hi! i'm searching difference in version.
There is not update CHANGES.rdoc so update :)

0.1.5 => 0.1.6
https://github.com/abenari/rbovirt/compare/e3431fd40932696f6ace59dc94649447834a1292...9f5c9055420aee74a776e493f7c2683662a11ea1

0.1.6 => 0.1.7
https://github.com/abenari/rbovirt/compare/9f5c9055420aee74a776e493f7c2683662a11ea1...e88ffd2ef7470c164a34dd4229cbb8f5a7257265